### PR TITLE
Add `named` export to get metadata by short name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @digitalbazaar/credentials-context ChangeLog
 
+## 3.1.0 - 2024-xx-xx
+
+### Added
+- Export experimental `named` Map to associate "short names" to metadata. Can
+  be used to get context URLs from easier to remember names with code like
+  `vcNamed.get('v2').id`.
+
+### Changed
+- Rename experimental export `contextsMetadata` to `metadata`.
+
 ## 3.0.0 - 2024-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ npm install @digitalbazaar/credentials-context
 ## Usage
 
 ```js
-import {contexts, contextsMetadata} from '@digitalbazaar/credentials-context';
+import {contexts, metadata, named} from '@digitalbazaar/credentials-context';
 // or
-const {contexts, contextsMetadata} = require('@digitalbazaar/credentials-context');
+const {contexts, metadata, named} = require('@digitalbazaar/credentials-context');
 ```
 
 The `contexts` [Map][] can be used to access individual contexts by id or load
@@ -63,9 +63,13 @@ applications.
 
 The library exports two properties:
 - `contexts`: A [Map][] associating context URLs to context data.
-- `contextsMetadata`: A [Map][] associating context URLs to context metadata.
+- `metadata`: A [Map][] associating context URLs to context metadata.
+- `named`: A [Map][] associating short package specific names to context
+  metadata.
 
-Note that the `contextsMetadata` format is experimental and subject to change.
+Note that the `metadata` format is experimental and subject to change. The `id`
+field is expected to stay stable and can be used with the `named` Map to get a
+context URL for a short name such as `v2`.
 
 The context files are available in the published `contexts/` directory. The
 metadata has a URL for each context. Note that these files are semantically
@@ -77,9 +81,18 @@ strict file digests are not equivalent.
 The following contexts are available as of mid-2024. They track the published
 spec contexts.
 
-- `https://www.w3.org/2018/credentials/v1`: Stable.
-- `https://www.w3.org/ns/credentials/v2`: Under development.
-- `https://www.w3.org/ns/credentials/undefined-terms/v2`: Under development.
+- Verifiable Credentials v1.1 context
+  - URL: `https://www.w3.org/2018/credentials/v1`
+  - Short name: `v1`
+  - Status: stable
+- Verifiable Credentials v2.0 context
+  - URL: `https://www.w3.org/ns/credentials/v2`
+  - Short name: `v2`
+  - Status: under development
+- Verifiable Credentials v2.0 undefined terms context
+  - URL: `https://www.w3.org/ns/credentials/undefined-terms/v2`
+  - Short name: `undefined-terms-v2`
+  - Status: under development
 
 ## Developing
 

--- a/bin/serialize.js
+++ b/bin/serialize.js
@@ -2,13 +2,10 @@
 /*!
  * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
-import {contextsMetadata} from '../lib/index.js';
 import fs from 'node:fs';
+import {metadata} from '../lib/index.js';
 
 // Serialize the contexts as JSON-LD
-for(const metadata of contextsMetadata.values()) {
-  fs.writeFileSync(
-    metadata.url,
-    JSON.stringify(metadata.context, null, 2) + '\n'
-  );
+for(const {url, context} of metadata.values()) {
+  fs.writeFileSync(url, JSON.stringify(context, null, 2) + '\n');
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,28 +8,45 @@ import v2Context from './v2.js';
 // map of context id to context
 export const contexts = new Map();
 // map of context id to context metadata
-export const contextsMetadata = new Map();
+export const metadata = new Map();
+// map of short names to context metadata
+export const named = new Map();
 
-function setExportsFromMetadata({contexts, contextsMetadata, metadata}) {
-  contexts.set(metadata.id, metadata.context);
-  contextsMetadata.set(metadata.id, metadata);
+function setExportsFromMetadata({
+  contextsMap, metadataMap, namedMap, metadata
+}) {
+  contextsMap.set(metadata.id, metadata.context);
+  metadataMap.set(metadata.id, metadata);
+  namedMap.set(metadata.shortName, metadata);
 }
 
-setExportsFromMetadata({contexts, contextsMetadata, metadata: {
-  id: 'https://www.w3.org/ns/credentials/undefined-terms/v2',
-  type: 'ContextMetadata',
-  url: new URL('../contexts/undefined-terms-v2.jsonld', import.meta.url),
-  context: undefinedTermsV2Context
-}});
-setExportsFromMetadata({contexts, contextsMetadata, metadata: {
-  id: 'https://www.w3.org/2018/credentials/v1',
-  type: 'ContextMetadata',
-  url: new URL('../contexts/v1.jsonld', import.meta.url),
-  context: v1Context
-}});
-setExportsFromMetadata({contexts, contextsMetadata, metadata: {
-  id: 'https://www.w3.org/ns/credentials/v2',
-  type: 'ContextMetadata',
-  url: new URL('../contexts/v2.jsonld', import.meta.url),
-  context: v2Context
-}});
+setExportsFromMetadata({
+  contextsMap: contexts, metadataMap: metadata, namedMap: named,
+  metadata: {
+    id: 'https://www.w3.org/ns/credentials/undefined-terms/v2',
+    type: 'ContextMetadata',
+    shortName: 'undefined-terms-v2',
+    url: new URL('../contexts/undefined-terms-v2.jsonld', import.meta.url),
+    context: undefinedTermsV2Context
+  }
+});
+setExportsFromMetadata({
+  contextsMap: contexts, metadataMap: metadata, namedMap: named,
+  metadata: {
+    id: 'https://www.w3.org/2018/credentials/v1',
+    type: 'ContextMetadata',
+    shortName: 'v1',
+    url: new URL('../contexts/v1.jsonld', import.meta.url),
+    context: v1Context
+  }
+});
+setExportsFromMetadata({
+  contextsMap: contexts, metadataMap: metadata, namedMap: named,
+  metadata: {
+    id: 'https://www.w3.org/ns/credentials/v2',
+    type: 'ContextMetadata',
+    shortName: 'v2',
+    url: new URL('../contexts/v2.jsonld', import.meta.url),
+    context: v2Context
+  }
+});

--- a/test/context.common.cjs
+++ b/test/context.common.cjs
@@ -1,32 +1,49 @@
 /*!
  * Copyright (c) 2021-2024 Digital Bazaar, Inc. All rights reserved.
  */
-module.exports.tests = function({contexts, contextsMetadata, expect}) {
+module.exports.tests = function({contexts, metadata, named, expect}) {
   it('contexts', async () => {
-    expect(contextsMetadata).to.exist;
-    expect(contextsMetadata.size).to.equal(3);
+    expect(metadata).to.exist;
+    expect(metadata.size).to.equal(3);
   });
 
-  it('contextsMetadata', async () => {
-    expect(contextsMetadata).to.exist;
-    expect(contextsMetadata.size).to.equal(3);
+  it('metadata', async () => {
+    expect(metadata).to.exist;
+    expect(metadata.size).to.equal(3);
+  });
+
+  it('named', async () => {
+    expect(named).to.exist;
+    expect(named.size).to.equal(3);
   });
 
   it('contents', async () => {
     const ids = [
-      'https://www.w3.org/ns/credentials/undefined-terms/v2',
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/ns/credentials/v2'
+      {
+        id: 'https://www.w3.org/ns/credentials/undefined-terms/v2',
+        name: 'undefined-terms-v2'
+      },
+      {
+        id: 'https://www.w3.org/2018/credentials/v1',
+        name: 'v1'
+      },
+      {
+        id: 'https://www.w3.org/ns/credentials/v2',
+        name: 'v2'
+      }
     ];
 
-    for(const id of ids) {
+    for(const {id, name} of ids) {
       expect(contexts.has(id)).to.be.true;
-      expect(contextsMetadata.has(id)).to.be.true;
-      const cctx = contexts.get(id);
-      const mctx = contextsMetadata.get(id);
-      expect(cctx).to.have.property('@context');
-      expect(mctx.id).to.equal(id);
-      expect(cctx).to.deep.equal(mctx.context);
+      expect(metadata.has(id)).to.be.true;
+      expect(named.has(name)).to.be.true;
+      const ctx = contexts.get(id);
+      const md = metadata.get(id);
+      const nmd = named.get(name);
+      expect(ctx).to.have.property('@context');
+      expect(md.id).to.equal(id);
+      expect(ctx).to.deep.equal(md.context);
+      expect(nmd).to.equal(md);
     }
   });
 };

--- a/test/context.spec.cjs
+++ b/test/context.spec.cjs
@@ -7,12 +7,13 @@ const {expect} = chai;
 
 const {
   contexts,
-  contextsMetadata
+  metadata,
+  named
 } = require('../dist/main.cjs');
 const {
   tests
 } = require('./context.common.cjs');
 
 describe('Context (require)', () => {
-  tests({contexts, contextsMetadata, expect});
+  tests({contexts, metadata, named, expect});
 });

--- a/test/context.spec.js
+++ b/test/context.spec.js
@@ -7,12 +7,13 @@ const {expect} = chai;
 
 import {
   contexts,
-  contextsMetadata
+  metadata,
+  named
 } from '../lib/index.js';
 import {
   tests
 } from './context.common.cjs';
 
 describe('Context (import)', () => {
-  tests({contexts, contextsMetadata, expect});
+  tests({contexts, metadata, named, expect});
 });


### PR DESCRIPTION
This is an experimental feature to try and replace the "constants" exports and vars with something more programmatic and suitable to future automated tooling.

Added
- Export experimental `named` Map to associate "short names" to metadata. Can be used to get context URLs from easier to remember names with code like `vcNamed.get('v2').id`.

Changed
- Rename experimental export `contextsMetadata` to `metadata`.

